### PR TITLE
fix: load global client vars also for playbook.yml

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -12,6 +12,12 @@
     potos_runtype: 'daily'
 
   pre_tasks:
+    - name: read specs repo configuration
+      ansible.builtin.include_vars:
+        file: '/etc/potos/specs_repo.yml'
+        name: potos_specs
+      tags:
+        - always
     # To make sure that this task always executes, it is tagged with the special
     # tag "always". Therefore do not remove this tag!
     - name: template requirements.yml file


### PR DESCRIPTION
## Description

Currently the globally defined variables on iso creation are only loaded in the `prepare.yml` playbook but not in `playbook.yml`. To allow usage of variables such as `client_name` we need to load them also in the `playbook.yml`

## Dependencies

n/a
