### PR TITLE
feat: separate git from galaxy

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -37,12 +37,79 @@
       tags:
         - always
 
-    - name: get required roles with ansible galaxy
-      ansible.builtin.command:
-        cmd: 'ansible-galaxy install -f -r requirements.yml -p roles/'
-      changed_when: false
+    # Load roles from requirements file
+    - name: load roles from requirements file
+      ansible.builtin.set_fact:
+        potos_plays_roles: "{{ lookup('file', 'requirements.yml') | from_yaml }}"
       tags:
         - always
+
+    - name: remove old files  # args[module]
+      ansible.builtin.file:
+        state: "{{ item }}"
+        path: "roles/"
+        owner: 0
+        group: 0
+        mode: '0755'
+      loop:
+        - absent
+        - directory
+      changed_when: false
+
+    # Clone roles defined to use git via the git module, allowing us more configuration (especially with ssh) than pure ansible-galaxy
+    - name: load roles via git
+      ansible.builtin.git:
+        accept_newhostkey: true
+        clone: true
+        dest: '{{ "roles/" + item.name | default(item.src.split(".git")[0].split("/")[-1]) }}'
+        force: true
+        key_file: "{{ item.key_file | default(omit) }}"
+        repo: '{{ item.src | regex_replace("^git\+", "") }}'
+        single_branch: true
+        ssh_opts: "{{ item.ssh_opts | default(omit) }}"
+        version: "{{ item.version | default(omit) }}"
+      loop: "{{ potos_plays_roles }}"
+      when:
+        - item.src is defined
+        - (item.src | regex_search('^git\+')) or (item.scm is defined and item.scm == 'git')
+      tags:
+        - always
+
+    # Clone remaining roles via ansible-galaxy
+    - name: clone remaining role via ansible-galaxy
+      tags:
+        - always
+      block:
+        - name: get roles to be loaded via ansible-galaxy
+          ansible.builtin.set_fact:
+            potos_roles_galaxy: "{{ potos_roles_galaxy | default([]) + [item] }}"
+          loop: "{{ potos_plays_roles }}"
+          when:
+            - (item.src is defined and not item.src | regex_search('^git\+')) or (item.scm is defined and item.scm != 'git')
+
+        - name: get temp file to store requirements for roles to be loaded with ansible-galaxy
+          ansible.builtin.tempfile:
+            state: file
+            suffix: '.yml'
+          register: potos_plays_galaxy_temp
+          when: potos_roles_galaxy is defined
+
+        - name: write temp file with roles to be loaded from ansible-galaxy
+          ansible.builtin.copy:
+            content: "{{ potos_roles_galaxy | to_yaml }}"
+            dest: "{{ potos_plays_galaxy_temp.path }}"
+            mode: 0644
+            user: root
+            group: root
+          when: potos_roles_galaxy is defined
+
+        - name: load roles from ansible-galaxy
+          ansible.builtin.command:
+            cmd: "ansible-galaxy install -f -r {{ potos_plays_galaxy_temp.path }} -p roles/"
+          changed_when: false
+          when:
+            - potos_roles_galaxy is defined
+            - potos_roles_galaxy | length > 0
 
   tasks:
     - name: run all the required roles


### PR DESCRIPTION
## Description

With this PR the role pulling for roles specified to use git is separated from ansible-galaxy to allow much more flexibility for example when using ssh. Allowing a specific ssh key to be used for every role, allowing any ssh option etc.

This PR should **NOT** be a breaking change. 
In everycase if the role is not a git repo, ansible-galaxy is still used to load the role.

Fixes [#8](https://github.com/projectpotos/ansible-specs-potos/issues/8)

## Dependencies

n/a
