### PR TITLE
feat: add specs ssh support

### DIFF
--- a/prepare.yml
+++ b/prepare.yml
@@ -17,6 +17,9 @@
         repo: '{{ potos_specs.git_url }}/{{ potos_specs.git_repo }}.git'
         dest: '{{ playbook_dir }}/specs'
         version: '{{ potos_specs.git_branch }}'
+        key_file: '{% if potos_specs.git_ssh_key is defined and potos_specs.git_ssh_key %}/etc/potos/specs_key{% else %}{{omit}}{% endif %}'
+        accept_newhostkey: true
+        single_branch: true
       changed_when: False
       failed_when: False
   tasks:


### PR DESCRIPTION
## Description

Allows the usage of ssh deploy keys for the specs repo

## Dependencies

This PR depends on [#22](https://github.com/projectpotos/potos-iso-builder/pull/22) that the ssh key for the specs repo can be specified in the iso
